### PR TITLE
Update plugin URLs for deployed domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,24 +36,24 @@ You need to deploy this application to a public HTTPS endpoint. Options include:
 
 ### 2. Update Configuration Files
 
-After deployment, update these files with your actual domain:
+After deployment, update these files with your actual domain. If deploying to Vercel, for example `https://gravity-topaz.vercel.app`, the configuration would look like:
 
 **ai-plugin.json:**
 ```json
 {
   "api": {
-    "url": "https://your-actual-domain.com/openapi.yaml"
+    "url": "https://gravity-topaz.vercel.app/openapi.yaml"
   },
-  "logo_url": "https://your-actual-domain.com/logo.png",
-  "contact_email": "your-email@domain.com",
-  "legal_info_url": "https://your-actual-domain.com/legal"
+  "logo_url": "https://gravity-topaz.vercel.app/logo.png",
+  "contact_email": "support@gravity-topaz.vercel.app",
+  "legal_info_url": "https://gravity-topaz.vercel.app/legal"
 }
 ```
 
 **openapi.yaml:**
 ```yaml
 servers:
-  - url: https://your-actual-domain.com/api
+  - url: https://gravity-topaz.vercel.app/api
     description: Production API Server
 ```
 
@@ -83,15 +83,23 @@ Try these example prompts in ChatGPT:
 
 ## Local Development
 
+Run the setup script once to install dependencies:
+
 ```bash
 # Install dependencies
-npm install
+npm run setup
 
 # Start development server
 npm run dev
 
 # Push database schema
 npm run db:push
+```
+
+After dependencies are installed, you can verify TypeScript types with:
+
+```bash
+npm run check
 ```
 
 ## Environment Variables Required

--- a/ai-plugin.json
+++ b/ai-plugin.json
@@ -9,9 +9,9 @@
   },
   "api": {
     "type": "openapi",
-    "url": "https://your-app-name.vercel.app/openapi.yaml"
+    "url": "https://gravity-topaz.vercel.app/openapi.yaml"
   },
-  "logo_url": "https://your-app-name.vercel.app/logo.png",
-  "contact_email": "support@your-app-name.vercel.app",
-  "legal_info_url": "https://your-app-name.vercel.app/legal"
+  "logo_url": "https://gravity-topaz.vercel.app/logo.png",
+  "contact_email": "support@gravity-topaz.vercel.app",
+  "legal_info_url": "https://gravity-topaz.vercel.app/legal"
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,9 +5,9 @@ info:
   version: 1.0.0
   contact:
     name: AI Compliance Monitor
-    url: https://ai-compliance-monitor.replit.app
+    url: https://gravity-topaz.vercel.app
 servers:
-  - url: "https://your-app-name.vercel.app/api"
+  - url: "https://gravity-topaz.vercel.app/api"
     description: "Production API Server"
 
 paths:

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist && cp openapi.yaml dist/public/openapi.yaml && mkdir -p dist/public/.well-known && cp ai-plugin.json dist/public/.well-known/ai-plugin.json",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
+    "setup": "bash scripts/setup.sh",
     "db:push": "drizzle-kit push"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts",
-    "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist && cp openapi.yaml dist/public/openapi.yaml && mkdir -p dist/public/.well-known && cp ai-plugin.json dist/public/.well-known/ai-plugin.json",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Simple setup script to install NPM dependencies
+# Usage: npm run setup
+
+if [ ! -d node_modules ]; then
+  echo "Installing dependencies..."
+  npm install
+else
+  echo "Dependencies already installed"
+fi


### PR DESCRIPTION
## Summary
- update `ai-plugin.json` to reference gravity-topaz.vercel.app
- adjust `openapi.yaml` contact and server URLs

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_685eadb624888321b3311d23d78f30a5