### PR TITLE
Update README and config URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ This is a comprehensive AI compliance monitoring system for MedTech that can be 
 
 You need to deploy this application to a public HTTPS endpoint. Options include:
 
-**Replit (Current deployment):**
-- Already deployed at: `https://ai-compliance-shield-brendandonnell3.replit.app`
-- OpenAPI spec available at: `https://ai-compliance-shield-brendandonnell3.replit.app/openapi.yaml`
-- Plugin manifest at: `https://ai-compliance-shield-brendandonnell3.replit.app/.well-known/ai-plugin.json`
+**Vercel (Current deployment):**
+- Already deployed at: `https://gravity-topaz.vercel.app`
+- OpenAPI spec available at: `https://gravity-topaz.vercel.app/openapi.yaml`
+- Plugin manifest at: `https://gravity-topaz.vercel.app/.well-known/ai-plugin.json`
 
 **Other hosting options:**
 - Vercel: `npm run build` then deploy

--- a/ai-plugin.json
+++ b/ai-plugin.json
@@ -9,9 +9,9 @@
   },
   "api": {
     "type": "openapi",
-    "url": "https://your-app-name.vercel.app/openapi.yaml"
+    "url": "https://gravity-topaz.vercel.app/openapi.yaml"
   },
-  "logo_url": "https://your-app-name.vercel.app/logo.png",
-  "contact_email": "support@your-app-name.vercel.app",
-  "legal_info_url": "https://your-app-name.vercel.app/legal"
+  "logo_url": "https://gravity-topaz.vercel.app/logo.png",
+  "contact_email": "support@gravity-topaz.vercel.app",
+  "legal_info_url": "https://gravity-topaz.vercel.app/legal"
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,9 +5,9 @@ info:
   version: 1.0.0
   contact:
     name: AI Compliance Monitor
-    url: https://ai-compliance-monitor.replit.app
+    url: https://gravity-topaz.vercel.app
 servers:
-  - url: "https://your-app-name.vercel.app/api"
+  - url: "https://gravity-topaz.vercel.app/api"
     description: "Production API Server"
 
 paths:


### PR DESCRIPTION
## Summary
- replace references to Replit deployment with Vercel URL in README
- update server contact and server URLs in `openapi.yaml`
- set plugin manifest to use Vercel URL

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_685eb26474248321aef60bd3b301ceec